### PR TITLE
hard-code Spago to 0.8.0.0; use real ReaderT design pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
   - latestRelease
 
 install:
-  - npm i -g purescript@0.12.5 spago parcel
+  - npm i -g purescript@0.12.5 spago@0.8.0 parcel
 
 # Print version numbers
 before_script:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,8 +8,13 @@ Learn [`purescript-halogen`](https://github.com/slamdata/purescript-halogen), (`
 
 Before learning Halogen via this project, you will need to install the following. (If you don't have them already installed, see my purescript learning repo's [Install Guide](https://github.com/JordanMartinez/purescript-jordans-reference/blob/latestRelease/00-Getting-Started/02-Install-Guide.md)
 - purescript (v0.12.5)
-- spago (v0.7.5.0)
+- spago (v0.8.0.0)
 - parcel (v1.12.3)
+
+Or, to install them in one line
+```bash
+npm i -g purescript@0.12.5 spago@0.8.0 parcel
+```
 
 ## Target Audience
 

--- a/src/08-Going-Deeper/02-A-Different-Monad--ReaderT.purs
+++ b/src/08-Going-Deeper/02-A-Different-Monad--ReaderT.purs
@@ -3,11 +3,14 @@ module GoingDeeper.ADifferentMonad.ReaderT where
 import Prelude
 
 import CSS (backgroundColor, em, lightgreen, padding)
-import Control.Monad.Reader (runReaderT)
+import Control.Monad.Reader (class MonadAsk, ask, asks, runReaderT)
+import Control.Monad.Reader.Trans (ReaderT)
+import Control.Monad.Trans.Class as MonadTrans
 import Data.Const (Const)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Effect.Aff (launchAff_)
+import Effect.Aff (Aff, launchAff_)
+import Effect.Aff.Class (class MonadAff)
 import Effect.Class (class MonadEffect)
 import Halogen (liftEffect)
 import Halogen as H
@@ -16,14 +19,35 @@ import Halogen.HTML as HH
 import Halogen.HTML.CSS as CSS
 import Halogen.HTML.Events as HE
 import Halogen.VDom.Driver (runUI)
+import Type.Equality (class TypeEquals)
+import Type.Equality as TypeEquals
 import Web.HTML (window)
 import Web.HTML.Window (alert)
+
+type Env = { name :: String }
+newtype AppM a = AppM (ReaderT Env Aff a)
+
+derive newtype instance functorAppM :: Functor AppM
+derive newtype instance applyAppM :: Apply AppM
+derive newtype instance applicativeAppM :: Applicative AppM
+derive newtype instance bindAppM :: Bind AppM
+derive newtype instance monadAppM :: Monad AppM
+derive newtype instance monadEffectAppM :: MonadEffect AppM
+derive newtype instance monadAffAppM :: MonadAff AppM
+
+-- workaround for allowing type synonyms inside type class instances
+instance monadAsk :: (TypeEquals e Env) => MonadAsk e AppM where
+  ask = AppM (asks $ TypeEquals.from)
+
+runAppM :: Env -> AppM ~> Aff
+runAppM env (AppM program) = runReaderT program env
 
 main :: Effect Unit
 main =
     launchAff_ do
       body <- awaitBody
-      let topLevelComponent = H.hoist (\app -> runReaderT app unit) specialMonadComponent
+      let env = { name: "PureScript" }
+      let topLevelComponent = H.hoist (\app -> runAppM env app) specialMonadComponent
       runUI topLevelComponent unit body
 
 -- Below is a button component that, when clicked,
@@ -38,6 +62,7 @@ type NoChildSlots = ()
 
 specialMonadComponent :: forall m
                        . MonadEffect m
+                      => MonadAsk Env m
                       => H.Component HH.HTML Query Input Message m
 specialMonadComponent =
     H.mkComponent
@@ -62,5 +87,7 @@ specialMonadComponent =
     handleAction :: Action -> H.HalogenM State Action NoChildSlots Message m Unit
     handleAction = case _ of
       PrintAlert -> do
+        rec <- MonadTrans.lift $ ask
         liftEffect do
-          window >>= alert "We're using a non-Aff monad here"
+          window >>= alert ("We're using a non-Aff monad here. Name: " <>
+                            rec.name)


### PR DESCRIPTION
#13 originally failed to build because the Spago version wasn't hard-coded. So, it installed `0.8.0.0` instead of `0.7.5.0`.

Also, my example of the ReaderT design pattern didn't show the design pattern. Rather, it just showed how to use a monad transformer (ReaderT) rather than Aff. This PR updates it to use AppM. It still doesn't show the capabilities one could use, but those who know the ReaderT design pattern should already get how it works.