### PR TITLE
Fix typos in the first two chapters

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,7 +37,7 @@ npm i -g purescript@0.12.5 spago@0.8.0 parcel
 1. Git clone this project
 2. Run `spago build`
 3. Run `spago docs` (and refer to the docs via the `./generated-docs/index.html` file)
-4. Read through each folder using the same rules that I use in my learning repo (described [in the third bullet point here](https://github.com/JordanMartinez/purescript-jordans-reference#learning-purescript-using-this-project).
+4. Read through each folder using the same rules that I use in my learning repo (described [in the third bullet point here](https://github.com/JordanMartinez/purescript-jordans-reference#learning-purescript-using-this-project)).
 
 Don't want to clone-and-play? Then read through this repo using [the Table of Contents](./table-of-contents.md) file.
 

--- a/src/01-Static-HTML/03-Adding-Properties.md
+++ b/src/01-Static-HTML/03-Adding-Properties.md
@@ -41,8 +41,9 @@ import Scaffolding.StaticRenderer (StaticHTML)
 -- new imports
 import Halogen.HTML (ClassName(..))
 import Halogen.HTML.Properties (ButtonType(..))
+import Halogen.HTML.Properties as HP
 
-staticHtmlWithProps :: StaticHtml
+staticHtmlWithProps :: StaticHTML
 staticHtmlWithProps =
   HH.div
     [ HP.id_ "top-div" ]

--- a/src/01-Static-HTML/05-Adding-CSS.md
+++ b/src/01-Static-HTML/05-Adding-CSS.md
@@ -10,7 +10,7 @@ There's a few things to be aware of with the syntax:
 
 ### CSS' single and multi key-pair syntax
 
-When we have one key-value pair, we ues this syntax, `CSS.style $ key value`. When we wish to have multiple key-value pairs, we must use the monadic "do notation" syntax:
+When we have one key-value pair, we use this syntax, `CSS.style $ key value`. When we wish to have multiple key-value pairs, we must use the monadic "do notation" syntax:
 ```purescript
 import Halogen.CSS as CSS
 

--- a/src/02-Dynamic-HTML/03-Understanding-Monads.md
+++ b/src/02-Dynamic-HTML/03-Understanding-Monads.md
@@ -44,7 +44,7 @@ extractVal :: forall value. Box value -> value
 extractVal (Box value) = value
 ```
 
-Why not take the values out whenever we want? Because these `Box`es represent side-effectful functions. These functions are computations that causes something to occur or change in the "real world." For example:
+Why not take the values out whenever we want? Because these `Box`es represent side-effectful functions. These functions are computations that cause something to occur or change in the "real world." For example:
 - state manipulation
 - network requests
 - printing
@@ -106,7 +106,7 @@ program =
   )
 ```
 
-Step 2: Swap the `Box number` and `\argName` positions, change the direction of the arrows/`->`, and remove the unneeded paranthesis:
+Step 2: Swap the `Box number` and `\argName` positions, change the direction of the arrows/`->`, and remove the unneeded parenthesis:
 
 ```purescript
 program :: Box Int


### PR DESCRIPTION
While reading the first few chapters I stumbled upon this "record creation syntax" (it reminds me of RecordWildcards from haskell which makes it possible to "suck up" things from enclosing scope into the record) which I didn't remember from reading you purescript guide. Do you know if it's documented somewhere? https://github.com/JordanMartinez/learn-halogen/blob/latestRelease/src/03-Parent-Child-Relationships/01-Childlike-Components/02-Input-Only.purs#L28-L32