### PR TITLE
Feedback and example simplifications

### DIFF
--- a/src/02-Dynamic-HTML/02-Adding-State.purs
+++ b/src/02-Dynamic-HTML/02-Adding-State.purs
@@ -22,7 +22,7 @@ main :: Effect Unit
 main =
   -- We're going to run the same function below 3 times using
   -- the 3 values provided here.
-  runStateOnlyDynamicRenderer 1 2 3 simpleIntState
+  runStateOnlyDynamicRenderer 1 2 3
 
 -- | Shows how to use Halogen VDOM DSL to render dynamic HTML
 -- | (no event handling) based on the state value received.
@@ -36,19 +36,13 @@ simpleIntState state =
 -- | that is always rendered the same and does not include any event handling.
 type StaticHTML = H.ComponentHTML Unit () Aff
 
--- | A function that uses the `state` type's value to render HTML
--- | with no event-handling.
-type StateOnlyDynamicRenderer state = (state -> StaticHTML)
-
 -- | Uses the `state` type's value to render dynamic HTML
 -- | using 3 different state values.
-runStateOnlyDynamicRenderer :: forall state.
-                               state
-                            -> state
-                            -> state
-                            -> StateOnlyDynamicRenderer state
+runStateOnlyDynamicRenderer :: Int
+                            -> Int
+                            -> Int
                             -> Effect Unit
-runStateOnlyDynamicRenderer firstState secondState thirdState rendererFunction =
+runStateOnlyDynamicRenderer firstState secondState thirdState =
   launchAff_ do
     awaitLoad
 
@@ -56,19 +50,17 @@ runStateOnlyDynamicRenderer firstState secondState thirdState rendererFunction =
     div2 <- selectElement' "could not find 'div#second'" $ QuerySelector "#second"
     div3 <- selectElement' "could not find 'div#third'" $ QuerySelector "#third"
 
-    void $ runUI (stateOnlyStaticComponent firstState  rendererFunction) unit div1
-    void $ runUI (stateOnlyStaticComponent secondState rendererFunction) unit div2
-    void $ runUI (stateOnlyStaticComponent thirdState  rendererFunction) unit div3
+    void $ runUI (stateOnlyStaticComponent firstState  ) unit div1
+    void $ runUI (stateOnlyStaticComponent secondState ) unit div2
+    void $ runUI (stateOnlyStaticComponent thirdState  ) unit div3
 
 -- | Wraps Halogen types cleanly, so that one gets very clear compiler errors
-stateOnlyStaticComponent :: forall state.
-                            state
-                         -> StateOnlyDynamicRenderer state
+stateOnlyStaticComponent :: Int
                          -> H.Component HH.HTML (Const Unit) Unit Void Aff
-stateOnlyStaticComponent state dynamicRenderer =
+stateOnlyStaticComponent state =
   H.mkComponent
     { initialState: const state
-    , render: dynamicRenderer
+    , render: simpleIntState
     , eval: H.mkEval H.defaultEval
     }
 

--- a/src/03-Parent-Child-Relationships/02-Parentlike-Components/02-Basic-Container.purs
+++ b/src/03-Parent-Child-Relationships/02-Parentlike-Components/02-Basic-Container.purs
@@ -2,10 +2,7 @@ module ParentChildRelationships.ParentlikeComponents.BasicContainer where
 
 import Prelude
 
--- Imports for lesson
 import Halogen.HTML as HH
-
--- Imports for scaffolding
 import CSS (backgroundColor, fontSize, orange, padding, px)
 import Data.Const (Const)
 import Data.Maybe (Maybe(..))
@@ -18,81 +15,40 @@ import Halogen.HTML.CSS as CSS
 import Halogen.VDom.Driver (runUI)
 
 main :: Effect Unit
-main = runBasicContainerComponent basicContainer
-
--- | A basic parent that only acts like a container.
--- | To keep things simpler, it is static and only renders a static child.
-basicContainer :: BasicParentContainer
-basicContainer childComponent =
-  HH.div_
-    [ HH.div_ [ HH.text "This is the parent component " ]
-    , singleChild_noInputNoMessageNoQuery childComponent
-    ]
-
--- Scaffolded Code --
-
--- | A child component that only renders static html. It does not have state,
--- | respond to input, raise messages, or respond to queries.
-type RenderOnlyChildComponent = H.Component HH.HTML (Const Unit) Unit Void Aff
-
--- | A parent component that, when given the child component, will render
--- | itself and the child component. No other interaction occurs between them
--- | (e.g. input, messages, queries).
-type BasicParentContainer =
-  (RenderOnlyChildComponent -> StaticHtmlWithSingleChildComponent)
-
--- | A static html value that can also render a component
-type StaticHtmlWithSingleChildComponent =
-  H.ComponentHTML
-    Void
-    (child :: H.Slot
-                (Const Unit) -- no query type
-                Void         -- no message type
-                Unit         -- single child, so only unit for slot index
-    )
-    Aff
-
-_child :: SProxy "child"
-_child = SProxy
-
--- | Runs a `BasicParentContainer`, so that we can see our component in action.
-runBasicContainerComponent :: BasicParentContainer
-                           -> Effect Unit
-runBasicContainerComponent renderParent = do
+main = do
   launchAff_ do
     body <- awaitBody
-    let parentHtml = renderParent simpleChildComponent
-    runUI (basicContainerComponent parentHtml) unit body
+    runUI parentComponent unit body
 
-type RenderOnlyParentComponent = H.Component HH.HTML (Const Unit) Unit Void Aff
-
--- | Wraps Halogen types cleanly, so that one gets very clear compiler errors
-basicContainerComponent :: StaticHtmlWithSingleChildComponent
-                        -> RenderOnlyParentComponent
-basicContainerComponent staticHtml =
-  H.mkComponent
-    { initialState: \_ -> unit
-    , render: const staticHtml
-    , eval: H.mkEval H.defaultEval
-    }
-
--- | Renders a child that does not respond to input, raise messages, or respond
--- | to queries inside of a parent component
-singleChild_noInputNoMessageNoQuery :: RenderOnlyChildComponent -> StaticHtmlWithSingleChildComponent
-singleChild_noInputNoMessageNoQuery childComp =
-  HH.slot _child unit childComp unit (const Nothing)
-
--- | HTML written in Purescript via Halogen's HTML DSL
--- | that is always rendered the same and does not include any event handling.
-type StaticHTML = H.ComponentHTML Unit () Aff
+-- | A static parent that only acts like a container and renders a static child.
+-- | No other interaction occurs between parent and child (e.g. input, messages, queries).
+parentComponent :: StaticHtmlComponent
+parentComponent =
+    H.mkComponent
+      { initialState: \_ -> unit     -- ignore initial state
+      , render: const render
+      , eval: H.mkEval H.defaultEval -- ignore actions and queries
+      }
+  where
+    render :: StaticHtmlWithSingleChildComponent
+    render =
+      HH.div_
+        [ HH.div_ [ HH.text "This is the parent component " ]
+        , HH.slot -- slot for child component
+            _child          -- the slot address label
+            unit            -- (unused) the slot address index
+            childComponent  -- the child component for the slot
+            unit            -- (unused) the input value to pass to the component
+            (const Nothing) -- (unused) a function mapping outputs from the component to a query in the parent
+        ]
 
 -- | A simple child component that only renders content to the screen
-simpleChildComponent :: RenderOnlyChildComponent
-simpleChildComponent =
+childComponent :: StaticHtmlComponent
+childComponent =
     H.mkComponent
-      { initialState: \_ -> unit
+      { initialState: \_ -> unit     -- ignore initial state
       , render: const render
-      , eval: H.mkEval H.defaultEval
+      , eval: H.mkEval H.defaultEval -- ignore actions and queries
       }
   where
     render :: StaticHTML
@@ -104,3 +60,29 @@ simpleChildComponent =
             padding (px 20.0) (px 20.0) (px 20.0) (px 20.0)
         ]
         [ HH.text "This is the child component" ]
+
+-- | A component that only renders static html. It does not have state,
+-- | respond to input, raise messages, or respond to queries.
+type StaticHtmlComponent = H.Component HH.HTML (Const Unit) Unit Void Aff
+
+-- | A static html value that can also render a component
+type StaticHtmlWithSingleChildComponent =
+  H.ComponentHTML
+    Void -- Parent actions
+    ChildSlots
+    Aff
+
+type ChildSlots =
+  (child :: H.Slot
+              (Const Unit) -- no query type
+              Void         -- no message type
+              Unit         -- single child, so only unit for slot index
+  )
+
+-- | HTML written in Purescript via Halogen's HTML DSL
+-- | that is always rendered the same and does not include any event handling.
+type StaticHTML = H.ComponentHTML Unit () Aff
+
+-- Create a unique "child" label
+_child :: SProxy "child"
+_child = SProxy

--- a/src/03-Parent-Child-Relationships/02-Parentlike-Components/03-Single-Child/02-Input-Only.purs
+++ b/src/03-Parent-Child-Relationships/02-Parentlike-Components/03-Single-Child/02-Input-Only.purs
@@ -20,40 +20,50 @@ import Halogen.Aff (awaitBody)
 import Halogen.HTML.CSS as CSS
 import Halogen.VDom.Driver (runUI)
 
+-- | State of parent and child is an integer
+type State = Int
+
 main :: Effect Unit
-main = runParentWithInputOnlyChild renderParentWithInputOnlyChild
+main = do
+  launchAff_ do
+    body <- awaitBody
+    initialInt <- liftEffect $ randomInt 1 200
+    runUI parentComponent initialInt body
+
+-- | Parent component which contains a button and child component
+parentComponent :: H.Component HH.HTML (Const Unit) State Void Aff
+parentComponent =
+    H.mkComponent
+      { initialState: identity
+      , render: render
+      , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
+      }
+  where
+    render :: State -> ParentWithSingleChildInputOnly
+    render state =
+      HH.div_
+        [ HH.div_ [ HH.text "This is the parent component " ]
+        , HH.button
+          [ HE.onClick \_ -> Just RandomState]
+          [ HH.text "Click to send a random integer (the `input` value) \
+                    \to the child"
+          ]
+        , HH.slot -- slot for child component
+            _child          -- slot address label
+            unit            -- (unused) slot address index
+            childComponent  -- child component for the slot
+            state           -- input value to pass to the component
+            (const Nothing) -- (unused) function mapping outputs from component to parent query
+        ]
+
+    handleAction :: ParentAction
+                 -> H.HalogenM Int ParentAction ChildSlots Void Aff Unit
+    handleAction RandomState = do
+      randInt <- liftEffect $ randomInt 1 200
+      put randInt
 
 -- | The parent's only action is `RandomState`
 data ParentAction = RandomState
-
-renderParentWithInputOnlyChild :: RenderParentWithInputOnlyChild
-renderParentWithInputOnlyChild childComponent inputValue =
-  HH.div_
-    [ HH.div_ [ HH.text "This is the parent component " ]
-    , HH.button
-      [ HE.onClick \_ -> Just RandomState]
-      [ HH.text "Click to send a random integer (the `input` value) \
-                \to the child"
-      ]
-    , singleChild_input_NoMessageNoQuery childComponent inputValue
-    ]
-
--- Scaffolded Code --
-
--- | A parent component that, when given the child component, will render
--- | itself and the child component. No other interaction occurs between them
--- | (e.g. input, messages, queries).
-type RenderParentWithInputOnlyChild =
-  InputOnlyChildComponent -> Int -> ParentWithSingleChildInputOnly
-
--- | A child component that renders dynamic html. It has state and
--- | responds to input, but it does not raise messages, or respond to queries.
-type InputOnlyChildComponent = H.Component HH.HTML (Const Unit) Int Void Aff
-
--- | Defines a function for regenerating the input value that gets passed
--- | to the child.
-type HandleParentActionWithInputChild =
-  ParentAction -> H.HalogenM Int ParentAction ChildSlots Void Aff Unit
 
 -- | A parent component that can regenerate a new `state` value (an `Int`) value
 -- | and renders a child that can respond to the initial and "parent re-rendered"
@@ -74,42 +84,11 @@ type ChildSlots =
 _child :: SProxy "child"
 _child = SProxy
 
--- | Runs a `ParentWithInputOnlyChild`, so that we can see our component in action.
-runParentWithInputOnlyChild :: RenderParentWithInputOnlyChild
-                            -> Effect Unit
-runParentWithInputOnlyChild renderParent = do
-  launchAff_ do
-    body <- awaitBody
-    initialInt <- liftEffect $ randomInt 1 200
-    runUI (parentWithInput renderParent) initialInt body
-
--- | Wraps Halogen types cleanly, so that one gets very clear compiler errors
-parentWithInput :: RenderParentWithInputOnlyChild
-                -> H.Component HH.HTML (Const Unit) Int Void Aff
-parentWithInput renderParent =
-    H.mkComponent
-      { initialState: identity
-      , render: \state -> renderParent simpleChildComponent state
-      , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
-      }
-  where
-    handleAction :: ParentAction
-                 -> H.HalogenM Int ParentAction ChildSlots Void Aff Unit
-    handleAction RandomState = do
-      randInt <- liftEffect $ randomInt 1 200
-      put randInt
-
--- | Renders a child that does not respond to input, raise messages, or respond
--- | to queries inside of a parent component
-singleChild_input_NoMessageNoQuery :: InputOnlyChildComponent -> Int -> ParentWithSingleChildInputOnly
-singleChild_input_NoMessageNoQuery childComp input =
-  HH.slot _child unit childComp input (const Nothing)
-
-data ChildAction = SetState Int
+data ChildAction = SetState State
 
 -- | A simple child component that only renders content to the screen
-simpleChildComponent :: H.Component HH.HTML (Const Unit) Int Void Aff
-simpleChildComponent =
+childComponent :: H.Component HH.HTML (Const Unit) State Void Aff
+childComponent =
     H.mkComponent
       { initialState: identity
       , render: render
@@ -118,7 +97,7 @@ simpleChildComponent =
                                        }
       }
   where
-    render :: Int -> H.ComponentHTML ChildAction () Aff
+    render :: State -> H.ComponentHTML ChildAction () Aff
     render state =
       HH.div
         [ CSS.style do
@@ -129,5 +108,5 @@ simpleChildComponent =
         [ HH.text $ "This is the child component. The input value was: " <> show state ]
 
     handleAction :: ChildAction
-                 -> H.HalogenM Int ChildAction () Void Aff Unit
+                 -> H.HalogenM State ChildAction () Void Aff Unit
     handleAction (SetState i) = put i


### PR DESCRIPTION
This PR is only for sharing feedback on my experience learning Halogen through this repo and not meant to be merged.

I appreciate how the scaffolding technique tries not to overwhelm new users with too much new code at once, but there's a temptation to follow the call flow of the functions that appear in the unscaffolded sections. It's initially straightforward to trace, but eventually becomes unnecessarily taxing to maintain a mental model of all the additional nested layers of non-halogen functions and types.

I found that some reorganizing provided a much better picture of how everything fits together. I can't say whether it was the process of moving things around or the end result that helped clarify the concepts.

I'm curious if a teaching style that starts with your template would be a smoother experience. It could begin with an initial warning to ignore everything (as if it were scaffold code). Then as each chapter introduces a new piece of functionality, use comments to highlight the relevant code blocks that should make sense. Users are still free to glance outside of the approved code blocks though, and can hopefully quickly detect if they are encountering confusing territory that they should defer to a later chapter. 

Also, the changes in `src/02-Dynamic-HTML/02-Adding-State.purs` don't affect scaffolding, and I believe the core lesson content is still preserved, so let me know if that's something that could be merged, and I'll follow-up with a new PR that renames some functions for consistency.